### PR TITLE
Fix Inno Setup .ps script file highlighting 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Customise GitHub Linguist
+
+# Highlight Inno Setup's .ps files as Pascal
+*.ps linguist-language=Pascal
+# Include Markdown files in stats
+*.md linguist-detectable


### PR DESCRIPTION
Get Linguist to highlight `.ps` files as Pascal (fixes #58)

Also get Linguist to count Markdown files in repo stats (no related issue)